### PR TITLE
Add Gentoo package

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ ninja -C build install
 ### Arch Based:
 AUR package: https://aur.archlinux.org/packages/mpvpaper-git/
 
+### Gentoo:
+GURU package: https://gpo.zugaina.org/Overlays/guru/gui-apps/mpvpaper/
+
 ## Usage
 ### Running
 Simple example:


### PR DESCRIPTION
I packaged mpvpaper for Gentoo in the GURU overlay. Somewhere in the next 24h, the link I added to the README should start to work.