### PR TITLE
Memory error fixes, slight refactoring

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -345,7 +345,7 @@ static void *handle_auto_stop() {
 
 static void *handle_mpv_events() {
     pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
-    bool mpv_paused = 0;
+    int mpv_paused = 0;
     time_t start_time = time(NULL);
 
     const int MPV_OBSERVE_PAUSE = 1;


### PR DESCRIPTION
After building mpvpaper with the `-Db_sanitize=address` flag for meson, I found an ~uninitialized memory~ null pointer issue and an out-of-bounds access when starting the program; see attached commits for the fixes. The first commit does a bit of linked refactoring to make the way the options are transferred clearer; let me know if you'd prefer a minimal change that fixes the issue.