### PR TITLE
Allow rendering on multiple outputs with <output> = *

### DIFF
--- a/mpvpaper.man
+++ b/mpvpaper.man
@@ -54,6 +54,11 @@ Simple example:
 mpvpaper DP-2 /path/to/video
 .RE
 
+To play the same video on all outputs:
+.RS
+mpvpaper '*' /path/to/video
+.RE
+
 Forward mpv options by passing "--mpv-options" or "-o" like so:
 .RS
 mpvpaper -o "no-audio --loop-playlist shuffle" HDMI-A-1 www.url/to/playlist

--- a/src/holder.c
+++ b/src/holder.c
@@ -210,10 +210,12 @@ static void xdg_output_handle_done(void *data, struct zxdg_output_v1 *xdg_output
 
     struct display_output *output = data;
 
-    if (strcmp(output->name, output->state->monitor) == 0 && !output->layer_surface) {
+    bool name_ok = (strcmp(output->name, output->state->monitor) == 0) ||
+        (strcmp(output->state->monitor, "*") == 0);
+    if (name_ok && !output->layer_surface) {
         create_layer_surface(output);
     }
-    else {
+    if (!name_ok) {
         destroy_display_output(output);
     }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -133,6 +133,8 @@ static void render(struct display_output *output) {
     if (!eglMakeCurrent(egl_display, output->egl_surface, output->egl_surface, egl_context)) {
         cflp_error("Failed to make output surface current 0x%X", eglGetError());
     }
+    glViewport(0, 0, output->width * output->scale, output->height * output->scale);
+
     // Render frame
     mpv_render_context_render(mpv_glcontext, render_params);
 
@@ -656,10 +658,11 @@ static void layer_surface_configure(void *data, struct zwlr_layer_surface_v1 *su
         eglSwapInterval(egl_display, 0);
 
         glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-        glViewport(0, 0, output->width * output->scale, output->height * output->scale);
 
         // Start render loop
         render(output);
+    } else {
+        wl_egl_window_resize(output->egl_window, output->width * output->scale, output->height * output->scale, 0, 0);
     }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -737,12 +737,14 @@ static void xdg_output_handle_done(void *data, struct zxdg_output_v1 *xdg_output
 
     struct display_output *output = data;
 
-    if (strcmp(output->name, output->state->monitor) == 0 && !output->layer_surface) {
+    bool name_ok = (strcmp(output->name, output->state->monitor) == 0) ||
+        (strcmp(output->state->monitor, "*") == 0);
+    if (name_ok && !output->layer_surface) {
         if (VERBOSE)
             cflp_info("Output %s (%s) selected", output->name, output->identifier);
         create_layer_surface(output);
     }
-    else {
+    if (!name_ok) {
         if (VERBOSE)
             cflp_warning("Output %s (%s) not selected", output->name, output->identifier);
         destroy_display_output(output);


### PR DESCRIPTION
Example use: run the following on either a single or multi-monitor setup; the video should show on every display:
```
mpvpaper '*' /path/to/video
```

Notes:
* It looks like no extra changes will be needed for the --auto-stop feature, because it seems auto_stop is only triggered if _no_ outputs have displayed a frame/set `halt_info.frame_ready = 1` in the last two seconds; thus as long as one monitor is visible, mpvpaper will continue running.
* I measured the efficiency improvement with `intel_gpu_top` and a video drawn simultaneously on three small virtual outputs: running `mpvpaper '*' video.mkv` used only 20% of the hardware video decoding capacity, and total GPU power draw was 3 W ; while showing the same video with three independent copies of mpvpaper used 40% of the hardware video decoding capacity and increased power draw to 4.5W total.
