### PR TITLE
Fix char bug so opt parsing doesn't infinite loop

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -892,7 +892,7 @@ static void parse_command_line(int argc, char **argv, struct wl_state *state) {
     char *layer_name;
 
     char opt;
-    while ((opt = getopt_long(argc, argv, "hvfpsn:l:o:Z:", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "hvfpsn:l:o:Z:", long_options, NULL)) != 255) {
 
         switch (opt) {
             case 'h':

--- a/src/main.c
+++ b/src/main.c
@@ -891,8 +891,8 @@ static void parse_command_line(int argc, char **argv, struct wl_state *state) {
 
     char *layer_name;
 
-    char opt;
-    while ((opt = getopt_long(argc, argv, "hvfpsn:l:o:Z:", long_options, NULL)) != 255) {
+    int opt;
+    while ((opt = getopt_long(argc, argv, "hvfpsn:l:o:Z:", long_options, NULL)) != -1) {
 
         switch (opt) {
             case 'h':


### PR DESCRIPTION
After some debugging, I found out that on the changed line some systems always have `c != -1` where `c` is a char. This is solved by comparing against `255` instead, allowing options to be parsed on Asahi linux.