### PR TITLE
Fix selecting extra monitors when the identifier is an empty string

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -723,7 +723,7 @@ static void output_done(void *data, struct wl_output *wl_output) {
     struct display_output *output = data;
 
     bool name_ok = (strstr(output->state->monitor, output->name) != NULL) ||
-            (strstr(output->state->monitor, output->identifier) != NULL) ||
+            (strlen(output->identifier) != 0 && strstr(output->state->monitor, output->identifier) != NULL) ||
             (strcmp(output->state->monitor, "*") == 0);
     if (name_ok && !output->layer_surface) {
         if (VERBOSE)


### PR DESCRIPTION
When using Hyprland, creating a headless output causes issues since it doesn't have a description by default. 

This causes extra monitors to be selected since output->identifier is an empty string which results in the strstr comparison to not return NULL in these cases.

This PR addresses the problem by checking if output->identifier is empty before performing strstr. 