### PR TITLE
Handle egl/mpv reinitialization when output disconnects/reconnects fixes #97

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@ scanner_client_header=generator(scanner,output: '@BASENAME@-client-protocol.h',a
 
 protocols_src=[
   scanner_private_code.process('proto/wlr-layer-shell-unstable-v1.xml'),
-  scanner_private_code.process(wl_protocols.get_pkgconfig_variable('pkgdatadir')+'/stable/xdg-shell/xdg-shell.xml')
+  scanner_private_code.process(wl_protocols.get_variable(pkgconfig: 'pkgdatadir')+'/stable/xdg-shell/xdg-shell.xml')
 ]
 
 protocols_headers=[


### PR DESCRIPTION
This PR destroys the egl Context when an output is destroyed, and upon a new layer surface configuration re-initializes the egl context and mpv. This allows mpvpaper to continue working when using KVM or swapping monitors.

Also reorders the destruction of layers/egl to fix a segfault with nvidia wayland-egl.

Fixes #97 