### PR TITLE
mpv optimization and build warning fix

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@ scanner_client_header=generator(scanner,output: '@BASENAME@-client-protocol.h',a
 
 protocols_src=[
   scanner_private_code.process('proto/wlr-layer-shell-unstable-v1.xml'),
-  scanner_private_code.process(wl_protocols.get_pkgconfig_variable('pkgdatadir')+'/stable/xdg-shell/xdg-shell.xml')
+  scanner_private_code.process(wl_protocols.get_variable(pkgconfig:'pkgdatadir')+'/stable/xdg-shell/xdg-shell.xml')
 ]
 
 protocols_headers=[

--- a/src/main.c
+++ b/src/main.c
@@ -65,6 +65,8 @@ static mpv_render_context *mpv_glcontext;
 static int wakeup_fd;
 static char *video_path;
 static char *mpv_options = "";
+static char *gpu_context = NULL;
+static char *hwdec = NULL;
 static char *vulkan_device = NULL;
 
 static struct {
@@ -425,19 +427,17 @@ static void set_init_mpv_options(const struct wl_state *state) {
     mpv_set_option_string(mpv, "config", "yes");
     mpv_set_option_string(mpv, "background-color", "#00000000");
 
+    if (gpu_context && strcmp(gpu_context, "") != 0) {
+        mpv_set_option_string(mpv, "gpu-context", gpu_context);
+    }
+    // setting vulkan-device should automatically select vulkan hwdec
     if (vulkan_device && strcmp(vulkan_device, "") != 0) {
-      //forces waylandvk gpu context, vulkan hwdec and a GPU device so that we can specify which GPU mpv uses
-      mpv_set_option_string(mpv, "gpu-context", "waylandvk");
       mpv_set_option_string(mpv, "vulkan-device", vulkan_device);
       mpv_set_option_string(mpv, "hwdec", "vulkan");
     }
-
-    char *gpu_ctx = mpv_get_property_string(mpv, "options/gpu-context");
-    char *vk_dev  = mpv_get_property_string(mpv, "options/vulkan-device");
-    cflp_info("gpu-context=%s", gpu_ctx ? gpu_ctx : "(null)");
-    cflp_info("vulkan-device=%s", vk_dev ? vk_dev : "(null)");
-    mpv_free(gpu_ctx);
-    mpv_free(vk_dev);
+    if (hwdec && strcmp(hwdec, "") != 0) {
+        mpv_set_option_string(mpv, "hwdec", hwdec);
+    }
 
     // Convenience options passed for slideshow mode
     if (SLIDESHOW_TIME != 0) {
@@ -934,6 +934,8 @@ static void parse_command_line(int argc, char **argv, struct wl_state *state) {
         {"slideshow", required_argument, NULL, 'n'},
         {"layer", required_argument, NULL, 'l'},
         {"mpv-options", required_argument, NULL, 'o'},
+        {"gpu-context", required_argument, NULL, 'G'},
+        {"hwdec", required_argument, NULL, 'H'},
         {"vulkan-device", required_argument, NULL, 'V'},
         {0, 0, 0, 0}
     };
@@ -956,7 +958,9 @@ static void parse_command_line(int argc, char **argv, struct wl_state *state) {
         "                               And passes mpv options \"loop loop-playlist\" for convenience\n"
         "--layer        -l LAYER        Specifies shell surface layer to run on (background by default)\n"
         "--mpv-options  -o \"OPTIONS\"  Forwards mpv options (Must be within quotes\"\")\n"
-        "--vulkan-device -V DEVICE      Forces mpv vulkan-device to DEVICE - use mpv --vulkan-device=help for device identifiers (name or UUID is accepted) \n"
+        "--gpu-context  -G CONTEXT      Specifies graphical session context (see MPV documentation for more info)\n"
+        "--hwdec        -H DECODER      Enables specified HW decoder (see MPV documentation for more info)\n"
+        "--vulkan-device -V DEVICE      Forces mpv vulkan-device DEVICE and sets hwdec to vulkan (see MPV documentation for more info) \n"
         "\n"
         "* The auto options might not work as intended\n"
         "See the man page for more details\n";
@@ -964,7 +968,7 @@ static void parse_command_line(int argc, char **argv, struct wl_state *state) {
     char *layer_name;
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "hdvfpsn:l:o:V:Z:", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "hdvfpsn:l:o:G:H:V:Z:", long_options, NULL)) != -1) {
 
         switch (opt) {
             case 'h':
@@ -1031,14 +1035,23 @@ static void parse_command_line(int argc, char **argv, struct wl_state *state) {
                 mpv_options = strdup(optarg);
                 // Replace spaces with newlines
                 for (int i=0; i < (int)strlen(mpv_options); i++) {
-                    if (mpv_options[i] == ' ')
+                    if (mpv_options[i] == ' '){
                         mpv_options[i] = '\n';
+                    }
                 }
                 break;
 
+            case 'G':
+                gpu_context = strdup(optarg);
+                break;
+
+            case 'H':
+                hwdec = strdup(optarg);
+                break;
+
             case 'V':
-              vulkan_device = strdup(optarg);
-              break;
+                vulkan_device = strdup(optarg);
+                break;
 
             case 'Z': // Hidden option to recover video pos after stopping
                 halt_info.save_info = strdup(optarg);

--- a/src/main.c
+++ b/src/main.c
@@ -65,6 +65,7 @@ static mpv_render_context *mpv_glcontext;
 static int wakeup_fd;
 static char *video_path;
 static char *mpv_options = "";
+static char *vulkan_device = NULL;
 
 static struct {
     char **pauselist;
@@ -423,6 +424,20 @@ static void set_init_mpv_options(const struct wl_state *state) {
     mpv_set_option_string(mpv, "terminal", "yes");
     mpv_set_option_string(mpv, "config", "yes");
     mpv_set_option_string(mpv, "background-color", "#00000000");
+
+    if (vulkan_device && strcmp(vulkan_device, "") != 0) {
+      //forces waylandvk gpu context, vulkan hwdec and a GPU device so that we can specify which GPU mpv uses
+      mpv_set_option_string(mpv, "gpu-context", "waylandvk");
+      mpv_set_option_string(mpv, "vulkan-device", vulkan_device);
+      mpv_set_option_string(mpv, "hwdec", "vulkan");
+    }
+
+    char *gpu_ctx = mpv_get_property_string(mpv, "options/gpu-context");
+    char *vk_dev  = mpv_get_property_string(mpv, "options/vulkan-device");
+    cflp_info("gpu-context=%s", gpu_ctx ? gpu_ctx : "(null)");
+    cflp_info("vulkan-device=%s", vk_dev ? vk_dev : "(null)");
+    mpv_free(gpu_ctx);
+    mpv_free(vk_dev);
 
     // Convenience options passed for slideshow mode
     if (SLIDESHOW_TIME != 0) {
@@ -919,6 +934,7 @@ static void parse_command_line(int argc, char **argv, struct wl_state *state) {
         {"slideshow", required_argument, NULL, 'n'},
         {"layer", required_argument, NULL, 'l'},
         {"mpv-options", required_argument, NULL, 'o'},
+        {"vulkan-device", required_argument, NULL, 'V'},
         {0, 0, 0, 0}
     };
 
@@ -939,7 +955,8 @@ static void parse_command_line(int argc, char **argv, struct wl_state *state) {
         "--slideshow    -n SECS         Slideshow mode plays the next video in a playlist every ? seconds\n"
         "                               And passes mpv options \"loop loop-playlist\" for convenience\n"
         "--layer        -l LAYER        Specifies shell surface layer to run on (background by default)\n"
-        "--mpv-options  -o \"OPTIONS\"    Forwards mpv options (Must be within quotes\"\")\n"
+        "--mpv-options  -o \"OPTIONS\"  Forwards mpv options (Must be within quotes\"\")\n"
+        "--vulkan-device -V DEVICE      Forces mpv vulkan-device to DEVICE - use mpv --vulkan-device=help for device identifiers (name or UUID is accepted) \n"
         "\n"
         "* The auto options might not work as intended\n"
         "See the man page for more details\n";
@@ -947,7 +964,7 @@ static void parse_command_line(int argc, char **argv, struct wl_state *state) {
     char *layer_name;
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "hdvfpsn:l:o:Z:", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "hdvfpsn:l:o:V:Z:", long_options, NULL)) != -1) {
 
         switch (opt) {
             case 'h':
@@ -1018,6 +1035,10 @@ static void parse_command_line(int argc, char **argv, struct wl_state *state) {
                         mpv_options[i] = '\n';
                 }
                 break;
+
+            case 'V':
+              vulkan_device = strdup(optarg);
+              break;
 
             case 'Z': // Hidden option to recover video pos after stopping
                 halt_info.save_info = strdup(optarg);


### PR DESCRIPTION
Hi, first of all, great project, I've been using it for around 6 months and recently I upgraded my PC to a dual-GPU setup. This led me to a rabbit hole of trying to force mpvpaper to use my non-default GPU and in the process, I discovered that mpv tries to auto-guess hw decoder and defaults to one with (incidentally) the largest VRAM usage footprint.

While debugging mpvpaper on a non-default GPU, I found that the current libmpv render path used by mpvpaper is OpenGL-based, so options like standalone mpv's --vulkan-device do not currently provide the same behavior here. However, changing the hardware decoder still has an effect - in testing, using hwdec=vulkan reduced mpvpaper’s VRAM usage from ~1300 MB to ~600 MB compared with hwdec=nvdec (selected with default hwdec=auto). This PR exposes that configuration (+ some others for future support of vulkan in libmpv) so users can benefit from the lower VRAM footprint even though full non-default-GPU wallpaper rendering is still limited by the current libmpv render path.


TLDR; exposed some mpv parameters for future support of vulkan in libmpv embedded render API + fixed a meson.build deprecation warning