### PR TITLE
Add experimental Vulkan render backend

### DIFF
--- a/inc/vulkan_backend.h
+++ b/inc/vulkan_backend.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <wayland-client.h>
+#include <mpv/client.h>
+#include <mpv/render.h>
+
+struct vulkan_output;
+
+bool vulkan_backend_init(const char *device_name, int verbose);
+void vulkan_backend_destroy(void);
+mpv_render_context *vulkan_backend_create_mpv_context(mpv_handle *mpv,
+                                                       struct wl_display *display);
+struct vulkan_output *vulkan_output_create(struct wl_display *display,
+                                            struct wl_surface *surface,
+                                            uint32_t width,
+                                            uint32_t height);
+bool vulkan_output_resize(struct vulkan_output *output,
+                          uint32_t width,
+                          uint32_t height);
+bool vulkan_output_render(struct vulkan_output *output,
+                          mpv_render_context *render_context);
+void vulkan_output_destroy(struct vulkan_output *output);

--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,7 @@ wl_client=dependency('wayland-client')
 wl_egl=dependency('wayland-egl')
 egl=dependency('egl')
 mpv=dependency('mpv')
+vulkan=dependency('vulkan')
 threads=dependency('threads')
 
 scanner=find_program('wayland-scanner')
@@ -27,9 +28,9 @@ protocols_headers=[
 lib_protocols=static_library('protocols',protocols_src+protocols_headers,dependencies: wl_client)
 protocols_dep=declare_dependency(link_with: lib_protocols,sources: protocols_headers)
 
-executable(meson.project_name(), ['src/main.c', 'src/glad.c', 'src/cflogprinter.c'],
+executable(meson.project_name(), ['src/main.c', 'src/vulkan_backend.c', 'src/glad.c', 'src/cflogprinter.c'],
 include_directories : ['inc'],
-dependencies: [dl_dep, wl_client, wl_egl, egl, mpv, threads, protocols_dep], install: true)
+dependencies: [dl_dep, wl_client, wl_egl, egl, mpv, vulkan, threads, protocols_dep], install: true)
 
 shm_dep = cc.find_library('rt', required : false)
 executable(meson.project_name() + '-holder', ['src/holder.c'],

--- a/src/main.c
+++ b/src/main.c
@@ -23,6 +23,8 @@
 #include <mpv/client.h>
 #include <mpv/render_gl.h>
 
+#include "vulkan_backend.h"
+
 #include <cflogprinter.h>
 
 typedef unsigned int uint;
@@ -48,6 +50,7 @@ struct display_output {
     struct zwlr_layer_surface_v1 *layer_surface;
     struct wl_egl_window *egl_window;
     EGLSurface *egl_surface;
+    struct vulkan_output *vk_output;
 
     uint32_t width, height;
     uint32_t scale;
@@ -75,6 +78,8 @@ static mpv_render_context *mpv_glcontext;
 static int wakeup_fd;
 static char *video_path;
 static char *mpv_options = "";
+static bool USE_VULKAN = false;
+static char *VULKAN_DEVICE = NULL;
 
 static struct {
     char **pauselist;
@@ -125,6 +130,8 @@ static void exit_cleanup() {
 
     if (mpv_glcontext)
         mpv_render_context_free(mpv_glcontext);
+    if (USE_VULKAN)
+        vulkan_backend_destroy();
     if (mpv)
         mpv_terminate_destroy(mpv);
 
@@ -157,6 +164,36 @@ static void handle_signal(int signum) {
 const static struct wl_callback_listener wl_surface_frame_listener;
 
 static void render(struct display_output *output) {
+    if (USE_VULKAN) {
+        if (!output->vk_output)
+            return;
+
+        // A Wayland frame callback is part of the next surface commit.  Vulkan
+        // WSI performs that commit from vkQueuePresentKHR(), so the callback
+        // must be requested before presenting.  Requesting it afterwards leaves
+        // frame_callback non-NULL without any committed callback to wake us up,
+        // permanently blocking subsequent renders.
+        output->frame_callback = wl_surface_frame(output->surface);
+        if (!output->frame_callback) {
+            cflp_error("Failed to create Wayland frame callback for %s", output->name);
+            return;
+        }
+        wl_callback_add_listener(output->frame_callback, &wl_surface_frame_listener, output);
+
+        if (!vulkan_output_render(output->vk_output, mpv_glcontext)) {
+            // No usable presentation was queued. Do not leave the output
+            // waiting on a callback which may never be committed.
+            wl_callback_destroy(output->frame_callback);
+            output->frame_callback = NULL;
+            vulkan_output_resize(output->vk_output, output->width * output->scale,
+                                 output->height * output->scale);
+            return;
+        }
+
+        output->redraw_needed = false;
+        return;
+    }
+
     mpv_render_param render_params[] = {
         {MPV_RENDER_PARAM_OPENGL_FBO, &(mpv_opengl_fbo) {
             .fbo = 0,
@@ -558,19 +595,25 @@ static void init_mpv(const struct wl_state *state) {
     }
     mpv_free(vo_option);
 
-    // Have mpv render onto egl context
-    mpv_render_param params[] = {
-        {MPV_RENDER_PARAM_WL_DISPLAY, state->display},
-        {MPV_RENDER_PARAM_API_TYPE, MPV_RENDER_API_TYPE_OPENGL},
-        {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &(mpv_opengl_init_params){
-            .get_proc_address = get_proc_address_mpv,
-        }},
-        {MPV_RENDER_PARAM_INVALID, NULL},
-    };
-    mpv_err = mpv_render_context_create(&mpv_glcontext, mpv, params);
-    if (mpv_err < 0) {
-        cflp_error("Failed to initialize mpv GL context, %s", mpv_error_string(mpv_err));
-        exit_mpvpaper(EXIT_FAILURE);
+    if (USE_VULKAN) {
+        mpv_glcontext = vulkan_backend_create_mpv_context(mpv, state->display);
+        if (!mpv_glcontext)
+            exit_mpvpaper(EXIT_FAILURE);
+    } else {
+        // Have mpv render onto egl context
+        mpv_render_param params[] = {
+            {MPV_RENDER_PARAM_WL_DISPLAY, state->display},
+            {MPV_RENDER_PARAM_API_TYPE, MPV_RENDER_API_TYPE_OPENGL},
+            {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &(mpv_opengl_init_params){
+                .get_proc_address = get_proc_address_mpv,
+            }},
+            {MPV_RENDER_PARAM_INVALID, NULL},
+        };
+        mpv_err = mpv_render_context_create(&mpv_glcontext, mpv, params);
+        if (mpv_err < 0) {
+            cflp_error("Failed to initialize mpv GL context, %s", mpv_error_string(mpv_err));
+            exit_mpvpaper(EXIT_FAILURE);
+        }
     }
 
     // Restore video position after auto stop event
@@ -856,6 +899,8 @@ static void destroy_display_output(struct display_output *output) {
         zwlr_layer_surface_v1_destroy(output->layer_surface);
     if (output->surface != NULL)
         wl_surface_destroy(output->surface);
+    if (output->vk_output)
+        vulkan_output_destroy(output->vk_output);
     if (output->egl_surface)
         eglDestroySurface(egl_display, output->egl_surface);
     if (output->egl_window)
@@ -875,6 +920,23 @@ static void layer_surface_configure(void *data, struct zwlr_layer_surface_v1 *su
     output->height = height;
     zwlr_layer_surface_v1_ack_configure(surface, serial);
     wl_surface_set_buffer_scale(output->surface, output->scale);
+
+    if (USE_VULKAN) {
+        if (!output->vk_output) {
+            output->vk_output = vulkan_output_create(output->state->display, output->surface,
+                    output->width * output->scale, output->height * output->scale);
+            if (!output->vk_output) {
+                cflp_error("Failed to create Vulkan output for %s", output->name);
+                destroy_display_output(output);
+                return;
+            }
+            render(output);
+        } else {
+            vulkan_output_resize(output->vk_output, output->width * output->scale,
+                                 output->height * output->scale);
+        }
+        return;
+    }
 
     if (!output->egl_window) {
         output->egl_window = wl_egl_window_create(output->surface, output->width * output->scale,
@@ -1170,6 +1232,8 @@ static void parse_command_line(int argc, char **argv, struct wl_state *state) {
         {"slideshow", required_argument, NULL, 'n'},
         {"layer", required_argument, NULL, 'l'},
         {"mpv-options", required_argument, NULL, 'o'},
+        {"gpu-api", required_argument, NULL, 'G'},
+        {"vulkan-device", required_argument, NULL, 'V'},
         {0, 0, 0, 0}
     };
 
@@ -1201,7 +1265,7 @@ static void parse_command_line(int argc, char **argv, struct wl_state *state) {
     int auto_mode = 0;
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "hdvfpsa:n:l:o:Z:", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "hdvfpsa:n:l:o:G:V:Z:", long_options, NULL)) != -1) {
 
         switch (opt) {
             case 'h':
@@ -1316,6 +1380,20 @@ static void parse_command_line(int argc, char **argv, struct wl_state *state) {
                 }
                 mpv_options[write_index] = '\0';
                 break;
+            case 'G':
+                if (strcasecmp(optarg, "vulkan") == 0)
+                    USE_VULKAN = true;
+                else if (strcasecmp(optarg, "opengl") == 0)
+                    USE_VULKAN = false;
+                else {
+                    cflp_error("Unknown gpu-api '%s'; expected opengl or vulkan", optarg);
+                    exit(EXIT_FAILURE);
+                }
+                break;
+            case 'V':
+                VULKAN_DEVICE = strdup(optarg);
+                USE_VULKAN = true;
+                break;
             case 'Z': // Hidden option to recover video pos after stopping
                 halt_info.save_info = strdup(optarg);
                 break;
@@ -1415,9 +1493,14 @@ int main(int argc, char **argv) {
     // Don't start egl and mpv if just displaying outputs
     if (!SHOW_OUTPUTS) {
         // Init render before outputs
-        init_egl(&state);
-        if (VERBOSE)
-            cflp_success("EGL initialized");
+        if (USE_VULKAN) {
+            if (!vulkan_backend_init(VULKAN_DEVICE, VERBOSE))
+                return EXIT_FAILURE;
+        } else {
+            init_egl(&state);
+            if (VERBOSE)
+                cflp_success("EGL initialized");
+        }
         init_mpv(&state);
         init_threads();
         if (VERBOSE)
@@ -1494,7 +1577,8 @@ int main(int argc, char **argv) {
                 // Redraw immediately if not waiting for frame callback
                 if (output->frame_callback == NULL) {
                     // Avoid crash when output is destroyed
-                    if (output->egl_window && output->egl_surface) {
+                    if ((USE_VULKAN && output->vk_output) ||
+                        (!USE_VULKAN && output->egl_window && output->egl_surface)) {
                         if (VERBOSE == 2)
                             cflp_info("MPV is ready to render the next frame for %s", output->name);
                         render(output);

--- a/src/vulkan_backend.c
+++ b/src/vulkan_backend.c
@@ -1,0 +1,583 @@
+#include "vulkan_backend.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_wayland.h>
+#include <mpv/render_vk.h>
+
+#include <cflogprinter.h>
+
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+
+struct vulkan_state {
+    VkInstance instance;
+    VkPhysicalDevice physical_device;
+    VkDevice device;
+    VkQueue queue;
+    uint32_t queue_family;
+    VkPhysicalDeviceFeatures2 enabled_features2;
+    VkPhysicalDeviceVulkan12Features enabled_features12;
+    const char *enabled_extensions[16];
+    uint32_t enabled_extension_count;
+    int verbose;
+};
+
+struct vulkan_output {
+    VkSurfaceKHR surface;
+    VkSwapchainKHR swapchain;
+    VkFormat format;
+    VkExtent2D extent;
+    VkImage *images;
+    VkImageView *views;
+    VkSemaphore *render_finished;
+    bool *image_initialized;
+    uint32_t image_count;
+    VkFence image_acquired;
+};
+
+static struct vulkan_state vk;
+
+static const char *vk_result_string(VkResult result)
+{
+    switch (result) {
+    case VK_SUCCESS: return "VK_SUCCESS";
+    case VK_NOT_READY: return "VK_NOT_READY";
+    case VK_TIMEOUT: return "VK_TIMEOUT";
+    case VK_SUBOPTIMAL_KHR: return "VK_SUBOPTIMAL_KHR";
+    case VK_ERROR_OUT_OF_DATE_KHR: return "VK_ERROR_OUT_OF_DATE_KHR";
+    case VK_ERROR_INITIALIZATION_FAILED: return "VK_ERROR_INITIALIZATION_FAILED";
+    case VK_ERROR_DEVICE_LOST: return "VK_ERROR_DEVICE_LOST";
+    case VK_ERROR_EXTENSION_NOT_PRESENT: return "VK_ERROR_EXTENSION_NOT_PRESENT";
+    case VK_ERROR_FEATURE_NOT_PRESENT: return "VK_ERROR_FEATURE_NOT_PRESENT";
+    case VK_ERROR_INCOMPATIBLE_DRIVER: return "VK_ERROR_INCOMPATIBLE_DRIVER";
+    default: return "unknown Vulkan error";
+    }
+}
+
+static bool has_device_extension(VkPhysicalDevice physical_device, const char *name)
+{
+    uint32_t count = 0;
+    if (vkEnumerateDeviceExtensionProperties(physical_device, NULL, &count, NULL) != VK_SUCCESS)
+        return false;
+
+    VkExtensionProperties *extensions = calloc(count, sizeof(*extensions));
+    if (!extensions)
+        return false;
+
+    bool found = false;
+    if (vkEnumerateDeviceExtensionProperties(physical_device, NULL, &count, extensions) == VK_SUCCESS) {
+        for (uint32_t i = 0; i < count; i++) {
+            if (strcmp(extensions[i].extensionName, name) == 0) {
+                found = true;
+                break;
+            }
+        }
+    }
+    free(extensions);
+    return found;
+}
+
+static bool append_extension_if_available(VkPhysicalDevice physical_device,
+                                          const char *name,
+                                          bool required)
+{
+    if (!has_device_extension(physical_device, name)) {
+        if (required)
+            cflp_error("Required Vulkan device extension is unavailable: %s", name);
+        return !required;
+    }
+
+    if (vk.enabled_extension_count >= ARRAY_SIZE(vk.enabled_extensions)) {
+        cflp_error("Too many Vulkan device extensions");
+        return false;
+    }
+
+    vk.enabled_extensions[vk.enabled_extension_count++] = name;
+    return true;
+}
+
+static bool select_physical_device(const char *device_name)
+{
+    uint32_t count = 0;
+    VkResult result = vkEnumeratePhysicalDevices(vk.instance, &count, NULL);
+    if (result != VK_SUCCESS || count == 0) {
+        cflp_error("No Vulkan physical devices found (%s)", vk_result_string(result));
+        return false;
+    }
+
+    VkPhysicalDevice *devices = calloc(count, sizeof(*devices));
+    if (!devices)
+        return false;
+    vkEnumeratePhysicalDevices(vk.instance, &count, devices);
+
+    int best_score = -1;
+    for (uint32_t i = 0; i < count; i++) {
+        VkPhysicalDeviceProperties properties;
+        vkGetPhysicalDeviceProperties(devices[i], &properties);
+
+        if (vk.verbose)
+            cflp_info("Vulkan device: %s", properties.deviceName);
+
+        if (device_name && device_name[0] && strcmp(device_name, properties.deviceName) != 0)
+            continue;
+
+        uint32_t queue_count = 0;
+        vkGetPhysicalDeviceQueueFamilyProperties(devices[i], &queue_count, NULL);
+        VkQueueFamilyProperties *queues = calloc(queue_count, sizeof(*queues));
+        if (!queues)
+            continue;
+        vkGetPhysicalDeviceQueueFamilyProperties(devices[i], &queue_count, queues);
+
+        for (uint32_t q = 0; q < queue_count; q++) {
+            if (!(queues[q].queueFlags & VK_QUEUE_GRAPHICS_BIT))
+                continue;
+
+            int score = properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU ? 100 : 10;
+            if (device_name && device_name[0])
+                score = 1000;
+            if (score > best_score) {
+                vk.physical_device = devices[i];
+                vk.queue_family = q;
+                best_score = score;
+            }
+            break;
+        }
+        free(queues);
+    }
+
+    free(devices);
+    if (!vk.physical_device) {
+        if (device_name && device_name[0])
+            cflp_error("Requested Vulkan device was not found: %s", device_name);
+        else
+            cflp_error("No Vulkan device with a graphics queue was found");
+        return false;
+    }
+
+    return true;
+}
+
+bool vulkan_backend_init(const char *device_name, int verbose)
+{
+    memset(&vk, 0, sizeof(vk));
+    vk.verbose = verbose;
+
+    VkApplicationInfo app_info = {
+        .sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
+        .pApplicationName = "mpvpaper",
+        .applicationVersion = VK_MAKE_VERSION(1, 0, 0),
+        .pEngineName = "libmpv",
+        .engineVersion = VK_MAKE_VERSION(1, 0, 0),
+        .apiVersion = VK_API_VERSION_1_3,
+    };
+
+    const char *instance_extensions[] = {
+        VK_KHR_SURFACE_EXTENSION_NAME,
+        VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME,
+    };
+    VkInstanceCreateInfo instance_info = {
+        .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+        .pApplicationInfo = &app_info,
+        .enabledExtensionCount = ARRAY_SIZE(instance_extensions),
+        .ppEnabledExtensionNames = instance_extensions,
+    };
+
+    VkResult result = vkCreateInstance(&instance_info, NULL, &vk.instance);
+    if (result != VK_SUCCESS) {
+        cflp_error("Failed to create Vulkan instance: %s", vk_result_string(result));
+        return false;
+    }
+
+    if (!select_physical_device(device_name))
+        goto fail;
+
+    if (!append_extension_if_available(vk.physical_device, VK_KHR_SWAPCHAIN_EXTENSION_NAME, true))
+        goto fail;
+    append_extension_if_available(vk.physical_device, VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME, false);
+#ifdef VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME
+    append_extension_if_available(vk.physical_device, VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME, false);
+#endif
+#ifdef VK_KHR_VIDEO_QUEUE_EXTENSION_NAME
+    append_extension_if_available(vk.physical_device, VK_KHR_VIDEO_QUEUE_EXTENSION_NAME, false);
+#endif
+#ifdef VK_KHR_VIDEO_DECODE_QUEUE_EXTENSION_NAME
+    append_extension_if_available(vk.physical_device, VK_KHR_VIDEO_DECODE_QUEUE_EXTENSION_NAME, false);
+#endif
+#ifdef VK_KHR_VIDEO_DECODE_H264_EXTENSION_NAME
+    append_extension_if_available(vk.physical_device, VK_KHR_VIDEO_DECODE_H264_EXTENSION_NAME, false);
+#endif
+#ifdef VK_KHR_VIDEO_DECODE_H265_EXTENSION_NAME
+    append_extension_if_available(vk.physical_device, VK_KHR_VIDEO_DECODE_H265_EXTENSION_NAME, false);
+#endif
+
+    VkPhysicalDeviceVulkan12Features supported12 = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES,
+    };
+    VkPhysicalDeviceFeatures2 supported2 = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2,
+        .pNext = &supported12,
+    };
+    vkGetPhysicalDeviceFeatures2(vk.physical_device, &supported2);
+    if (!supported12.timelineSemaphore || !supported12.hostQueryReset) {
+        cflp_error("Selected device lacks timelineSemaphore or hostQueryReset support");
+        goto fail;
+    }
+
+    vk.enabled_features12 = (VkPhysicalDeviceVulkan12Features) {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES,
+        .timelineSemaphore = VK_TRUE,
+        .hostQueryReset = VK_TRUE,
+    };
+    vk.enabled_features2 = (VkPhysicalDeviceFeatures2) {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2,
+        .pNext = &vk.enabled_features12,
+    };
+
+    float priority = 1.0f;
+    VkDeviceQueueCreateInfo queue_info = {
+        .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+        .queueFamilyIndex = vk.queue_family,
+        .queueCount = 1,
+        .pQueuePriorities = &priority,
+    };
+    VkDeviceCreateInfo device_info = {
+        .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
+        .pNext = &vk.enabled_features2,
+        .queueCreateInfoCount = 1,
+        .pQueueCreateInfos = &queue_info,
+        .enabledExtensionCount = vk.enabled_extension_count,
+        .ppEnabledExtensionNames = vk.enabled_extensions,
+    };
+
+    result = vkCreateDevice(vk.physical_device, &device_info, NULL, &vk.device);
+    if (result != VK_SUCCESS) {
+        cflp_error("Failed to create Vulkan device: %s", vk_result_string(result));
+        goto fail;
+    }
+    vkGetDeviceQueue(vk.device, vk.queue_family, 0, &vk.queue);
+
+    VkPhysicalDeviceProperties properties;
+    vkGetPhysicalDeviceProperties(vk.physical_device, &properties);
+    if (vk.verbose)
+        cflp_success("Vulkan initialized on %s", properties.deviceName);
+    return true;
+
+fail:
+    vulkan_backend_destroy();
+    return false;
+}
+
+void vulkan_backend_destroy(void)
+{
+    if (vk.device) {
+        vkDeviceWaitIdle(vk.device);
+        vkDestroyDevice(vk.device, NULL);
+    }
+    if (vk.instance)
+        vkDestroyInstance(vk.instance, NULL);
+    memset(&vk, 0, sizeof(vk));
+}
+
+mpv_render_context *vulkan_backend_create_mpv_context(mpv_handle *mpv,
+                                                       struct wl_display *display)
+{
+    mpv_render_context *context = NULL;
+    mpv_vulkan_init_params init = {
+        .instance = vk.instance,
+        .physical_device = vk.physical_device,
+        .device = vk.device,
+        .graphics_queue = vk.queue,
+        .graphics_queue_family = vk.queue_family,
+        .get_instance_proc_addr = vkGetInstanceProcAddr,
+        .features = &vk.enabled_features2,
+        .extensions = vk.enabled_extensions,
+        .num_extensions = vk.enabled_extension_count,
+    };
+    const char *backend = "gpu-next";
+    mpv_render_param params[] = {
+        {MPV_RENDER_PARAM_WL_DISPLAY, display},
+        {MPV_RENDER_PARAM_API_TYPE, MPV_RENDER_API_TYPE_VULKAN},
+        {MPV_RENDER_PARAM_BACKEND, (void *)backend},
+        {MPV_RENDER_PARAM_VULKAN_INIT_PARAMS, &init},
+        {MPV_RENDER_PARAM_INVALID, NULL},
+    };
+
+    int error = mpv_render_context_create(&context, mpv, params);
+    if (error < 0) {
+        cflp_error("Failed to initialize mpv Vulkan context: %s", mpv_error_string(error));
+        return NULL;
+    }
+    return context;
+}
+
+static void destroy_swapchain(struct vulkan_output *output)
+{
+    if (!output)
+        return;
+    if (vk.device)
+        vkDeviceWaitIdle(vk.device);
+    for (uint32_t i = 0; i < output->image_count; i++) {
+        if (output->render_finished && output->render_finished[i])
+            vkDestroySemaphore(vk.device, output->render_finished[i], NULL);
+        if (output->views && output->views[i])
+            vkDestroyImageView(vk.device, output->views[i], NULL);
+    }
+    free(output->image_initialized);
+    free(output->render_finished);
+    free(output->views);
+    free(output->images);
+    output->image_initialized = NULL;
+    output->render_finished = NULL;
+    output->views = NULL;
+    output->images = NULL;
+    output->image_count = 0;
+    if (output->swapchain)
+        vkDestroySwapchainKHR(vk.device, output->swapchain, NULL);
+    output->swapchain = VK_NULL_HANDLE;
+}
+
+static bool create_swapchain(struct vulkan_output *output, uint32_t width, uint32_t height)
+{
+    VkBool32 present_supported = VK_FALSE;
+    vkGetPhysicalDeviceSurfaceSupportKHR(vk.physical_device, vk.queue_family,
+                                         output->surface, &present_supported);
+    if (!present_supported) {
+        cflp_error("Selected Vulkan graphics queue cannot present to this Wayland surface");
+        return false;
+    }
+
+    VkSurfaceCapabilitiesKHR caps;
+    if (vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vk.physical_device, output->surface, &caps) != VK_SUCCESS)
+        return false;
+
+    uint32_t format_count = 0;
+    vkGetPhysicalDeviceSurfaceFormatsKHR(vk.physical_device, output->surface, &format_count, NULL);
+    VkSurfaceFormatKHR *formats = calloc(format_count, sizeof(*formats));
+    if (!formats)
+        return false;
+    vkGetPhysicalDeviceSurfaceFormatsKHR(vk.physical_device, output->surface, &format_count, formats);
+
+    VkSurfaceFormatKHR selected = formats[0];
+    for (uint32_t i = 0; i < format_count; i++) {
+        if (formats[i].format == VK_FORMAT_B8G8R8A8_UNORM &&
+            formats[i].colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
+            selected = formats[i];
+            break;
+        }
+    }
+    free(formats);
+
+    VkExtent2D extent = {width, height};
+    if (caps.currentExtent.width != UINT32_MAX)
+        extent = caps.currentExtent;
+    else {
+        if (extent.width < caps.minImageExtent.width) extent.width = caps.minImageExtent.width;
+        if (extent.height < caps.minImageExtent.height) extent.height = caps.minImageExtent.height;
+        if (extent.width > caps.maxImageExtent.width) extent.width = caps.maxImageExtent.width;
+        if (extent.height > caps.maxImageExtent.height) extent.height = caps.maxImageExtent.height;
+    }
+
+    uint32_t image_count = caps.minImageCount + 1;
+    if (caps.maxImageCount && image_count > caps.maxImageCount)
+        image_count = caps.maxImageCount;
+
+    VkSwapchainKHR old_swapchain = output->swapchain;
+    VkSwapchainCreateInfoKHR info = {
+        .sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
+        .surface = output->surface,
+        .minImageCount = image_count,
+        .imageFormat = selected.format,
+        .imageColorSpace = selected.colorSpace,
+        .imageExtent = extent,
+        .imageArrayLayers = 1,
+        .imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
+        .imageSharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        .preTransform = caps.currentTransform,
+        .compositeAlpha = (caps.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR)
+                            ? VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR
+                            : VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
+        .presentMode = VK_PRESENT_MODE_FIFO_KHR,
+        .clipped = VK_TRUE,
+        .oldSwapchain = old_swapchain,
+    };
+
+    VkSwapchainKHR new_swapchain;
+    VkResult result = vkCreateSwapchainKHR(vk.device, &info, NULL, &new_swapchain);
+    if (result != VK_SUCCESS) {
+        cflp_error("Failed to create Vulkan swapchain: %s", vk_result_string(result));
+        return false;
+    }
+
+    if (old_swapchain)
+        destroy_swapchain(output);
+    output->swapchain = new_swapchain;
+    output->format = selected.format;
+    output->extent = extent;
+
+    vkGetSwapchainImagesKHR(vk.device, output->swapchain, &output->image_count, NULL);
+    output->images = calloc(output->image_count, sizeof(*output->images));
+    output->views = calloc(output->image_count, sizeof(*output->views));
+    output->render_finished = calloc(output->image_count, sizeof(*output->render_finished));
+    output->image_initialized = calloc(output->image_count, sizeof(*output->image_initialized));
+    if (!output->images || !output->views || !output->render_finished ||
+        !output->image_initialized)
+        return false;
+    vkGetSwapchainImagesKHR(vk.device, output->swapchain, &output->image_count, output->images);
+
+    for (uint32_t i = 0; i < output->image_count; i++) {
+        VkImageViewCreateInfo view_info = {
+            .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+            .image = output->images[i],
+            .viewType = VK_IMAGE_VIEW_TYPE_2D,
+            .format = output->format,
+            .subresourceRange = {
+                .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                .baseMipLevel = 0,
+                .levelCount = 1,
+                .baseArrayLayer = 0,
+                .layerCount = 1,
+            },
+        };
+        result = vkCreateImageView(vk.device, &view_info, NULL, &output->views[i]);
+        if (result != VK_SUCCESS) {
+            cflp_error("Failed to create Vulkan image view: %s", vk_result_string(result));
+            return false;
+        }
+
+        VkSemaphoreCreateInfo semaphore_info = {
+            .sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
+        };
+        result = vkCreateSemaphore(vk.device, &semaphore_info, NULL,
+                                   &output->render_finished[i]);
+        if (result != VK_SUCCESS) {
+            cflp_error("Failed to create Vulkan render semaphore: %s",
+                       vk_result_string(result));
+            return false;
+        }
+    }
+    return true;
+}
+
+struct vulkan_output *vulkan_output_create(struct wl_display *display,
+                                            struct wl_surface *surface,
+                                            uint32_t width,
+                                            uint32_t height)
+{
+    struct vulkan_output *output = calloc(1, sizeof(*output));
+    if (!output)
+        return NULL;
+
+    VkWaylandSurfaceCreateInfoKHR surface_info = {
+        .sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR,
+        .display = display,
+        .surface = surface,
+    };
+    VkResult result = vkCreateWaylandSurfaceKHR(vk.instance, &surface_info, NULL, &output->surface);
+    if (result != VK_SUCCESS) {
+        cflp_error("Failed to create Vulkan Wayland surface: %s", vk_result_string(result));
+        free(output);
+        return NULL;
+    }
+
+    VkFenceCreateInfo fence_info = {
+        .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
+    };
+    result = vkCreateFence(vk.device, &fence_info, NULL, &output->image_acquired);
+    if (result != VK_SUCCESS || !create_swapchain(output, width, height)) {
+        vulkan_output_destroy(output);
+        return NULL;
+    }
+    return output;
+}
+
+bool vulkan_output_resize(struct vulkan_output *output, uint32_t width, uint32_t height)
+{
+    return output && create_swapchain(output, width, height);
+}
+
+bool vulkan_output_render(struct vulkan_output *output,
+                          mpv_render_context *render_context)
+{
+    uint32_t image_index = 0;
+    vkResetFences(vk.device, 1, &output->image_acquired);
+    VkResult result = vkAcquireNextImageKHR(vk.device, output->swapchain, UINT64_MAX,
+                                            VK_NULL_HANDLE, output->image_acquired,
+                                            &image_index);
+    if (result == VK_ERROR_OUT_OF_DATE_KHR)
+        return false;
+    if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR) {
+        cflp_error("Failed to acquire Vulkan swapchain image: %s", vk_result_string(result));
+        return false;
+    }
+
+    mpv_vulkan_fbo fbo = {
+        .image = output->images[image_index],
+        .image_view = output->views[image_index],
+        .width = output->extent.width,
+        .height = output->extent.height,
+        .format = output->format,
+        .current_layout = output->image_initialized[image_index]
+                            ? VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
+                            : VK_IMAGE_LAYOUT_UNDEFINED,
+        .target_layout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+    };
+    if (vkWaitForFences(vk.device, 1, &output->image_acquired, VK_TRUE,
+                        UINT64_MAX) != VK_SUCCESS) {
+        cflp_error("Failed waiting for Vulkan swapchain image");
+        return false;
+    }
+
+    // Let libmpv signal this binary semaphore from the GPU once rendering and
+    // the final PRESENT_SRC_KHR layout transition are complete.  Present waits
+    // on it directly, avoiding a full CPU/GPU round trip for every frame.
+    mpv_vulkan_sync sync = {
+        .signal_semaphore = output->render_finished[image_index],
+    };
+    mpv_render_param params[] = {
+        {MPV_RENDER_PARAM_VULKAN_FBO, &fbo},
+        {MPV_RENDER_PARAM_VULKAN_SYNC, &sync},
+        {MPV_RENDER_PARAM_BLOCK_FOR_TARGET_TIME, &(int){0}},
+        {MPV_RENDER_PARAM_INVALID, NULL},
+    };
+
+    int error = mpv_render_context_render(render_context, params);
+    if (error < 0) {
+        cflp_error("Failed to render Vulkan frame with mpv: %s", mpv_error_string(error));
+        return false;
+    }
+
+    VkPresentInfoKHR present = {
+        .sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
+        .waitSemaphoreCount = 1,
+        .pWaitSemaphores = &output->render_finished[image_index],
+        .swapchainCount = 1,
+        .pSwapchains = &output->swapchain,
+        .pImageIndices = &image_index,
+    };
+    result = vkQueuePresentKHR(vk.queue, &present);
+    if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR)
+        return false;
+    if (result != VK_SUCCESS) {
+        cflp_error("Failed to present Vulkan frame: %s", vk_result_string(result));
+        return false;
+    }
+
+    output->image_initialized[image_index] = true;
+    mpv_render_context_report_swap(render_context);
+    return true;
+}
+
+void vulkan_output_destroy(struct vulkan_output *output)
+{
+    if (!output)
+        return;
+    destroy_swapchain(output);
+    if (output->image_acquired)
+        vkDestroyFence(vk.device, output->image_acquired, NULL);
+    if (output->surface)
+        vkDestroySurfaceKHR(vk.instance, output->surface, NULL);
+    free(output);
+}


### PR DESCRIPTION
## Summary

This adds Vulkan rendering backend to mpvpaper.

mpvpaper now creates its own Vulkan instance, device, Wayland surface, swapchain and presentation loop, and passes Vulkan image targets to a Vulkan-capable libmpv render API.

The existing EGL/OpenGL backend remains the default.

## Relation to #123

I originally opened #123 while investigating high VRAM usage and GPU selection in a dual-GPU setup.

That PR was written quickly as a narrow workaround. Project activity appeared low enough that I was unsure whether a larger rendering refactor would be reviewed, and I also did not want to first track down the quoting problem in the generic `-o` parser. I therefore exposed the relevant options directly.

That was useful for settings such as `hwdec=vulkan`, which reduced VRAM usage on my system, but it was never intended to claim that mpvpaper itself was rendering through Vulkan. The final render context was still OpenGL.

The review correctly noted that real Vulkan support required changes to mpvpaper's initialization and rendering pipeline. This PR implements those changes.

## Usage

```sh
mpvpaper \
    --gpu-api=vulkan \
    --vulkan-device="NVIDIA GeForce GTX 1660 SUPER" \
    -o "no-audio loop-file=inf hwdec=vulkan" \
    '*' \
    wallpaper.mp4
```

New options:

```text
--gpu-api=opengl|vulkan
--vulkan-device=<physical device name>
```

## Implementation

The Vulkan backend:

* selects a physical device by name
* creates a Wayland Vulkan surface and swapchain for each output
* renders libmpv directly into swapchain images
* uses per-image semaphores for asynchronous presentation
* transitions images to `VK_IMAGE_LAYOUT_PRESENT_SRC_KHR`
* recreates the swapchain after resize or an out-of-date result

The `-o` parser was also updated to preserve quoted and escaped values containing spaces.

## Dependency

This branch depends on the proposed [Vulkan libmpv Render API](https://github.com/mpv-player/mpv/pull/18258)

Until that API is available in a normal mpv release, this backend requires a custom mpv build and should be considered experimental.

## Testing

Tested on Garuda Linux with Wayland/Hyprland, NVIDIA driver 610.43.02, an RTX 4070 driving the compositor and a GTX 1660 SUPER selected for mpvpaper rendering.

4K H.264 videos played and looped correctly with Vulkan hardware decoding. `nvidia-smi` confirmed that mpvpaper was running on the selected GTX 1660 SUPER.

The OpenGL backend remains the default and is unchanged unless Vulkan is explicitly selected.


<img width="809" height="643" alt="image" src="https://github.com/user-attachments/assets/829c3c2f-5c56-469b-a5ee-965d42651419" />